### PR TITLE
Handle additional YDB round-trip parser cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,17 +113,26 @@ The plugin parses YDB/YQL back into sqlglot's AST, enabling round-trips, YDB-to-
 | `$variable` references | `SELECT * FROM $t AS t` |
 | `Module::Function()` | `DateTime::GetYear(ts)` |
 | `DECLARE $p AS Type` | `DECLARE $p AS Int32` |
-| `FLATTEN [LIST\|DICT] BY col` | `FROM t FLATTEN LIST BY col` |
+| `FLATTEN [LIST\|DICT\|OPTIONAL] BY ...` / `FLATTEN COLUMNS` | `FROM t FLATTEN LIST BY col AS item`, `FROM t FLATTEN BY (a, b)`, `FROM t FLATTEN COLUMNS` |
 | `Optional<T>` / `T?` | `CAST(x AS Optional<Utf8>)` |
 | Container types | `CAST(x AS List<Int32>)`, `Dict<Utf8, Int64>`, `Set<Utf8>`, `Tuple<Int32, Utf8>` |
 | `ASSUME ORDER BY` | `SELECT * FROM t ASSUME ORDER BY id` |
-| `GROUP BY expr AS alias` | `SELECT v, COUNT(*) FROM t GROUP BY v AS v` |
+| `GROUP BY expr AS alias` / `GROUP COMPACT BY` | `SELECT v, COUNT(*) FROM t GROUP BY v AS v` |
+| `LEFT ONLY JOIN` | `SELECT * FROM a LEFT ONLY JOIN b USING (id)` |
+| `* WITHOUT (...)` projections | `SELECT b.* WITHOUT (b.id) FROM t AS b` |
 | Named expressions | `$t = (SELECT 1 AS x)` |
 | Lambda expressions | `($x, $y?) -> ($x + COALESCE($y, 0))`, `($y) -> { $p = "x"; RETURN $p \|\| $y }` |
+| YQL struct literals | `AsList(<|user_id: "u1", description: NULL|>)` |
 | `IN COMPACT` | `WHERE key IN COMPACT $values` |
 | `PRAGMA` | `PRAGMA AnsiImplicitCrossJoin` |
+| Table-valued functions | `SELECT * FROM AS_TABLE($Input) AS k` |
+| Table source options and index views | ``FROM `t` WITH TabletId='...'``, ``FROM `t` VIEW PRIMARY KEY v`` |
+| Function-valued expressions | `$grep(x)`, `DateTime::Format("%Y-%m-%d")(ts)`, `Interval("P7D")` |
 
 Table names without backticks are accepted on input; the generator always produces backtick-quoted output.
+
+The parser also tolerates case variants that appear in real YQL dumps, such as
+`set<Utf8>`, `Tuple<Int32, Utf8>?`, and lowercase `return` in lambda blocks.
 
 #### CTEs reassembly
 
@@ -180,6 +189,7 @@ Functions below are recognized by sqlglot as standard SQL expressions and transl
 | `INTERVAL n HOUR` (literal) | `DateTime::IntervalFromHours(n)` |
 | `INTERVAL n MINUTE` (literal) | `DateTime::IntervalFromMinutes(n)` |
 | `INTERVAL n SECOND` (literal) | `DateTime::IntervalFromSeconds(n)` |
+| `Interval("P7D")` (YQL input) | passed through unchanged |
 | `dateDiff('minute', a, b)` | `(CAST(b AS Int64) - CAST(a AS Int64)) / 60000000` |
 | `dateDiff('hour', a, b)` | `(CAST(b AS Int64) - CAST(a AS Int64)) / 3600000000` |
 | `dateDiff('day', a, b)` | `(CAST(b AS Int64) - CAST(a AS Int64)) / 86400000000` |
@@ -229,6 +239,10 @@ arguments and block bodies with local named expressions:
 ($y) -> { $prefix = "x"; RETURN $prefix || $y; };
 ```
 
+ClickHouse `ARRAY JOIN` and simple `arrayJoin(...)` projections, and PostgreSQL
+`LATERAL unnest(...)`, are converted to YDB `FLATTEN BY` when the operation is
+directly tied to the source table.
+
 ### Conditional / math
 
 | Input | YQL output |
@@ -242,6 +256,18 @@ arguments and block bodies with local named expressions:
 | Input | YQL output |
 |---|---|
 | `jsonb_col @> value` (PostgreSQL) | `Yson::Contains(jsonb_col, value)` |
+
+YDB JSON functions are parsed and round-tripped, including `PASSING`,
+`RETURNING`, wrapper modes, and `ON EMPTY` / `ON ERROR` clauses:
+
+```sql
+JSON_VALUE(payload, '$.value + $delta' PASSING 1 AS delta RETURNING Int64 DEFAULT 0 ON EMPTY ERROR ON ERROR)
+JSON_QUERY(payload, '$.items' WITH CONDITIONAL ARRAY WRAPPER NULL ON EMPTY ERROR ON ERROR)
+JSON_EXISTS(payload, '$.items[$Index]' PASSING 0 AS "Index" FALSE ON ERROR)
+```
+
+JSON paths can contain quoted keys, for example
+`JSON_EXISTS(item_result, "$.'P_008 device playback test'")`.
 
 ---
 

--- a/tests/unit/test_ydb.py
+++ b/tests/unit/test_ydb.py
@@ -785,12 +785,41 @@ class TestYDBParser(Validator):
     def test_regular_order_by_unchanged(self):
         self.validate_identity("SELECT * FROM `t` ORDER BY id")
 
+    def test_yql_interval_function_before_group_by(self):
+        self.validate_transpile(
+            "SELECT device_id FROM `table` WHERE CurrentUtcDate() - Interval('P7D') > ts GROUP BY device_id",
+            "SELECT device_id FROM `table` WHERE CurrentUtcDate() - Interval('P7D') > ts GROUP BY device_id AS device_id",
+        )
+
+    def test_leading_bom_before_named_expression(self):
+        expressions = parse("\ufeff\n$date_parse = DateTime::Parse('format');", dialect="ydb")
+        self.assertEqual(expressions[0].sql(dialect="ydb"), "$date_parse = DateTime::Parse('format')")
+
+    def test_leading_mojibake_bom_before_named_expression(self):
+        expressions = parse("ï»¿\n$date_parse = DateTime::Parse('format');", dialect="ydb")
+        self.assertEqual(expressions[0].sql(dialect="ydb"), "$date_parse = DateTime::Parse('format')")
+
+    def test_struct_literal(self):
+        self.validate_identity("$profile = AsList(<|user_id: 'u1', description: NULL|>)")
+
+    def test_json_path_with_quoted_key(self):
+        self.validate_transpile(
+            'SELECT JSON_EXISTS(item_result, "$.\'P_008 device playback test\'") FROM `t`',
+            "SELECT JSON_EXISTS(item_result, '$.''P_008 device playback test''') FROM `t`",
+        )
+
     # --- Lambda expressions -------------------------------------------------
 
     def test_lambda_return_body_with_semicolon(self):
         self.validate_identity(
             "ListFilter($counterIds, ($x) -> {RETURN $x > $startCounterId;})",
             write_sql="ListFilter($counterIds, ($x) -> ($x > $startCounterId))",
+        )
+
+    def test_lambda_lowercase_return_body_with_semicolon(self):
+        self.validate_identity(
+            "ListMap($contacts, ($i) -> { return Digest::MurMurHash($i); })",
+            write_sql="ListMap($contacts, ($i) -> (Digest::MurMurHash($i)))",
         )
 
     def test_in_compact_parameter(self):

--- a/ydb_sqlglot/ydb.py
+++ b/ydb_sqlglot/ydb.py
@@ -432,6 +432,11 @@ class YdbAtString(exp.Expression):
     arg_types = {"this": True}
 
 
+class YdbStructLiteral(exp.Expression):
+    """YDB struct literal, e.g. <|key: value, ...|>."""
+    arg_types = {"expressions": False}
+
+
 class YdbPostfixCall(exp.Expression):
     """YDB call of an expression result, e.g. $grep(x) or DateTime::Format(fmt)(ts)."""
     arg_types = {"this": True, "expressions": False}
@@ -684,6 +689,14 @@ class YDB(Dialect):
         def parse(self, raw_tokens, sql=None):
             self.reset()
             self.sql = sql or ""
+            raw_tokens = [
+                token
+                for token in raw_tokens
+                if not (
+                    token.token_type == TokenType.VAR
+                    and token.text in ("\ufeff", "ï»¿")
+                )
+            ]
 
             chunks: t.List[t.List[tokens.Token]] = [[]]
             brace_depth = 0
@@ -1123,6 +1136,24 @@ class YDB(Dialect):
                 fallback_to_identifier=fallback_to_identifier,
             )
 
+        def _parse_interval(self, require_interval: bool = True) -> t.Optional[exp.Expression]:
+            if (
+                self._curr
+                and self._curr.token_type == TokenType.INTERVAL
+                and self._next
+                and self._next.token_type == TokenType.L_PAREN
+            ):
+                self._advance()
+                self._match(TokenType.L_PAREN)
+                args = self._parse_csv(self._parse_assignment)
+                self._match_r_paren()
+                return self.expression(exp.Anonymous(this="Interval", expressions=args))
+
+            try:
+                return super()._parse_interval(require_interval=require_interval)
+            except TypeError:
+                return super()._parse_interval()
+
         def _parse_ydb_postfix_calls(
             self,
             expression: t.Optional[exp.Expression],
@@ -1469,6 +1500,14 @@ class YDB(Dialect):
         def _parse_primary(self) -> t.Optional[exp.Expression]:
             if (
                 self._curr
+                and self._curr.token_type == TokenType.LT
+                and self._next
+                and self._next.token_type == TokenType.PIPE
+            ):
+                return self._parse_ydb_struct_literal()
+
+            if (
+                self._curr
                 and self._curr.token_type == TokenType.PARAMETER
                 and self._next
                 and self._next.token_type == TokenType.PARAMETER
@@ -1533,6 +1572,31 @@ class YDB(Dialect):
                 return this
             return super()._parse_primary()
 
+        def _parse_ydb_struct_literal(self) -> YdbStructLiteral:
+            self._advance()  # <
+            self._advance()  # |
+            fields = self._parse_csv(self._parse_ydb_struct_literal_field)
+            self._match(TokenType.PIPE_GT)
+            return self.expression(
+                YdbStructLiteral(expressions=[field for field in fields if field])
+            )
+
+        def _parse_ydb_struct_literal_field(self) -> t.Optional[exp.Expression]:
+            if self._curr and self._curr.token_type == TokenType.PIPE_GT:
+                return None
+
+            key = self._parse_id_var(any_token=True)
+            if not key:
+                self.raise_error("Expected struct literal key")
+            if not self._match(TokenType.COLON):
+                self.raise_error("Expected colon after struct literal key")
+
+            value = self._parse_assignment()
+            if not value:
+                self.raise_error("Expected struct literal value")
+
+            return self.expression(exp.PropertyEQ(this=key, expression=value))
+
         def _next_matching_rparen_is_arrow(self) -> bool:
             depth = 1
             # _tokens_size is not available in all supported sqlglot versions.
@@ -1586,7 +1650,7 @@ class YDB(Dialect):
             assignments = []
 
             if has_brace:
-                while self._curr and self._curr.text != "RETURN":
+                while self._curr and self._curr.text.upper() != "RETURN":
                     index = self._index
                     if self._curr.token_type != TokenType.PARAMETER:
                         self.raise_error("Expected lambda body assignment or RETURN after '->'")
@@ -1796,6 +1860,12 @@ class YDB(Dialect):
 
         def ydbatstring_sql(self, expression: YdbAtString) -> str:
             return f"@@{expression.this}@@"
+
+        def ydbstructliteral_sql(self, expression: YdbStructLiteral) -> str:
+            fields = []
+            for field in expression.expressions:
+                fields.append(f"{self.sql(field, 'this')}: {self.sql(field, 'expression')}")
+            return f"<|{', '.join(fields)}|>"
 
         def ydbpostfixcall_sql(self, expression: YdbPostfixCall) -> str:
             this = self.sql(expression, "this")
@@ -3815,6 +3885,7 @@ class YDB(Dialect):
             AssumeOrderBy: lambda self, e: self.assumeorderby_sql(e),
             YdbTuple: lambda self, e: self.ydbtuple_sql(e),
             YdbAtString: lambda self, e: self.ydbatstring_sql(e),
+            YdbStructLiteral: lambda self, e: self.ydbstructliteral_sql(e),
             YdbPostfixCall: lambda self, e: self.ydbpostfixcall_sql(e),
             YdbJsonExists: lambda self, e: self.ydbjsonexists_sql(e),
             YdbJsonQuery: lambda self, e: self.ydbjsonquery_sql(e),


### PR DESCRIPTION
Parse YQL Interval(...) calls, struct literals, leading BOM tokens, and lowercase lambda RETURN blocks.

Add regression coverage for the reported round-trip failures, including quoted JSON path keys.